### PR TITLE
Add delay before Tagmonitor supervisor loop starts

### DIFF
--- a/packages/ceti-tag-data-capture/ipc/tagMonitor.sh
+++ b/packages/ceti-tag-data-capture/ipc/tagMonitor.sh
@@ -2,6 +2,9 @@
 
 # New for 2.1-4 release  11/5/22
 # Supervisor script for the Tag application
+# 
+# 12/15/22 MRC 
+# Updated with additional start up delay to accomodate read-only boot time
 
 # remount rootfs readonly
 mount /boot -o remount,ro
@@ -26,6 +29,11 @@ sleep  30
 
 # Launch the main recording application in the background
 sudo /opt/ceti-tag-data-capture/bin/cetiTagApp & 
+
+# Add another 2 minute holdoff before routine checking starts. This provides a window during
+# which the operator can intervene with the automatic shutdown in cases where the battery
+# has been deeply discharged 
+sleep  120
 
 # micro-SD storage and battery periodic monitoring  
 while :


### PR DESCRIPTION
Prevents login lockout that may occur after boot if battery is deeply discharged. This happens because there is not enough time between power on and network access before the battery is checked by the TagMonitor script.  Once the shutdown is scheduled, users are blocked from logging in by default.