### PR TITLE
Add battery temperature monitoring to V2_2

### DIFF
--- a/packages/ceti-tag-data-capture/src/_versioning.h
+++ b/packages/ceti-tag-data-capture/src/_versioning.h
@@ -4,8 +4,6 @@
 // Contributors: Matt Cummings, Peter Malkin, Joseph DelPreto [TODO: Add other contributors here]
 //-----------------------------------------------------------------------------
 //
-// Note - version must correspond with the repository release tag
-//
 // Version    Date    Description
 //  2_1.0   10/08/21   Begin work, establish framework
 //  2_1.1   06/27/22   Update v2.0 to work with v2.1 hardware

--- a/packages/ceti-tag-data-capture/src/_versioning.h
+++ b/packages/ceti-tag-data-capture/src/_versioning.h
@@ -15,11 +15,11 @@
 //  2_1.5   11/24/22   Change RAM buffer size to accomodate read-only rootfs
 //  2.1.6   12/03/22   Added ECG
 //  2.2.0   03/25/22   Refactored codebase, testing on Pi Zero 2
-//
+//  2.2.1   11/8/23    Adding battery temperature monitoring
 
 #ifndef CETI_VERSIONING_H
 #define CETI_VERSIONING_H
 
-#define CETI_VERSION "v2_2.0 release candidate - in test"
+#define CETI_VERSION "v2_2.1 - Adding battery temperature monitoring, in test"
 
 #endif // CETI_VERSIONING_H

--- a/packages/ceti-tag-data-capture/src/battery.c
+++ b/packages/ceti-tag-data-capture/src/battery.c
@@ -163,3 +163,28 @@ int getBatteryData(double* battery_v1_v, double* battery_v2_v,
     return (0);
 }
 
+//-----------------------------------------------------------------------------
+// Charge and Discharge Enabling
+//-----------------------------------------------------------------------------
+int enableCharging() {
+
+  return(0);
+}
+
+int disableCharging() {
+
+  return(0);
+
+}
+
+int enableDischarging() {
+
+  return(0);
+
+}
+
+int disableDischarging() {
+
+  return(0);
+
+}

--- a/packages/ceti-tag-data-capture/src/battery.c
+++ b/packages/ceti-tag-data-capture/src/battery.c
@@ -174,7 +174,7 @@ int enableCharging() {
   }
   else {
     temp = i2cReadByteData(fd,BATT_PROTECT);
-    i2cWriteByteData(fd,BATT_PROTECT, (temp | CE ) ); //establish undervoltage cutoff
+    i2cWriteByteData(fd,BATT_PROTECT, (temp | CE ) ); 
   }
   return(0);
 }
@@ -188,7 +188,7 @@ int disableCharging() {
   }
   else {
     temp = i2cReadByteData(fd,BATT_PROTECT);
-    i2cWriteByteData(fd,BATT_PROTECT, (temp & NCE)  ); //establish undervoltage cutoff
+    i2cWriteByteData(fd,BATT_PROTECT, (temp & NCE)  ); 
   }
   return(0);
 
@@ -202,7 +202,7 @@ int enableDischarging() {
   }
   else {
     temp = i2cReadByteData(fd,BATT_PROTECT);
-    i2cWriteByteData(fd,BATT_PROTECT, (temp | DE )  ); //establish undervoltage cutoff
+    i2cWriteByteData(fd,BATT_PROTECT, (temp | DE )  ); 
   }
   return(0);
 
@@ -216,7 +216,7 @@ int disableDischarging() {
   }
   else {
     temp = i2cReadByteData(fd,BATT_PROTECT);
-    i2cWriteByteData(fd,BATT_PROTECT, (temp & NDE )  ); //establish undervoltage cutoff
+    i2cWriteByteData(fd,BATT_PROTECT, (temp & NDE )  ); 
   }
   return(0);
 

--- a/packages/ceti-tag-data-capture/src/battery.c
+++ b/packages/ceti-tag-data-capture/src/battery.c
@@ -166,58 +166,111 @@ int getBatteryData(double* battery_v1_v, double* battery_v2_v,
 //-----------------------------------------------------------------------------
 // Charge and Discharge Enabling
 //-----------------------------------------------------------------------------
-int enableCharging() {
+int enableCharging(void) {
   int fd, temp;
   if((fd=i2cOpen(1,ADDR_BATT_GAUGE,0)) < 0) {
-    CETI_LOG("XXXX Failed to connect to the battery gauge XXXX");
+    CETI_LOG("Failed to connect to the BMS IC on I2C");
     return (-1);
   }
   else {
-    temp = i2cReadByteData(fd,BATT_PROTECT);
-    i2cWriteByteData(fd,BATT_PROTECT, (temp | CE ) ); 
+    if ( (temp = i2cReadByteData(fd,BATT_PROTECT))  >= 0 ) {
+      if ( (i2cWriteByteData(fd,BATT_PROTECT, (temp | CE))) == 0  ) { 
+        CETI_LOG("I2C write succeeded, enabled charging");
+        i2cClose(fd);
+        return(0);
+      }
+      else {
+        CETI_LOG("I2C write to BMS register failed");
+        i2cClose(fd);
+        return(-1);        
+      }
+    }
+    else {
+      CETI_LOG("Failed to read BMS register");
+      i2cClose(fd);
+      return(-1);
+    }
   }
-  return(0);
+}
+
+int disableCharging(void) {
+  int fd, temp;
+  if((fd=i2cOpen(1,ADDR_BATT_GAUGE,0)) < 0) {
+    CETI_LOG("Failed to connect to the BMS IC on I2C");
+    return (-1);
+  }
+  else {
+    if ( (temp = i2cReadByteData(fd,BATT_PROTECT))  >= 0 ) {
+      if ( (i2cWriteByteData(fd,BATT_PROTECT, (temp & ~CE))) == 0  ) { 
+        CETI_LOG("I2C write succeeded, disabled charging");
+        i2cClose(fd);
+        return(0);
+      }
+      else {
+        CETI_LOG("I2C write to BMS register failed");
+        i2cClose(fd);
+        return(-1);        
+      }
+    }
+    else {
+      CETI_LOG("Failed to read BMS register");
+      i2cClose(fd);
+      return(-1);
+    }
+  }
 }
 
 
-int disableCharging() {
+int enableDischarging(void) {
   int fd, temp;
   if((fd=i2cOpen(1,ADDR_BATT_GAUGE,0)) < 0) {
-    CETI_LOG("XXXX Failed to connect to the battery gauge XXXX");
+    CETI_LOG("Failed to connect to the BMS IC on I2C");
     return (-1);
   }
   else {
-    temp = i2cReadByteData(fd,BATT_PROTECT);
-    i2cWriteByteData(fd,BATT_PROTECT, (temp & NCE)  ); 
+    if ( (temp = i2cReadByteData(fd,BATT_PROTECT))  >= 0 ) {
+      if ( (i2cWriteByteData(fd,BATT_PROTECT, (temp | DE))) == 0  ) { 
+        CETI_LOG("I2C write succeeded, enabled discharging");
+        i2cClose(fd);
+        return(0);
+      }
+      else {
+        CETI_LOG("I2C write to BMS register failed");
+        i2cClose(fd);
+        return(-1);        
+      }
+    }
+    else {
+      CETI_LOG("Failed to read BMS register");
+      i2cClose(fd);
+      return(-1);
+    }
   }
-  return(0);
-
 }
 
-int enableDischarging() {
+int disableDischarging(void) {
   int fd, temp;
   if((fd=i2cOpen(1,ADDR_BATT_GAUGE,0)) < 0) {
-    CETI_LOG("XXXX Failed to connect to the battery gauge XXXX");
+    CETI_LOG("Failed to connect to the BMS IC on I2C");
     return (-1);
   }
   else {
-    temp = i2cReadByteData(fd,BATT_PROTECT);
-    i2cWriteByteData(fd,BATT_PROTECT, (temp | DE )  ); 
+    if ( (temp = i2cReadByteData(fd,BATT_PROTECT))  >= 0 ) {
+      if ( (i2cWriteByteData(fd,BATT_PROTECT, (temp & ~DE))) == 0  ) { 
+        CETI_LOG("I2C write succeeded, disabled discharging");
+        i2cClose(fd);
+        return(0);
+      }
+      else {
+        CETI_LOG("I2C write to BMS register failed");
+        i2cClose(fd);
+        return(-1);        
+      }
+    }
+    else {
+      CETI_LOG("Failed to read BMS register");
+      i2cClose(fd);
+      return(-1);
+    }
   }
-  return(0);
-
-}
-
-int disableDischarging() {
-  int fd, temp;
-  if((fd=i2cOpen(1,ADDR_BATT_GAUGE,0)) < 0) {
-    CETI_LOG("XXXX Failed to connect to the battery gauge XXXX");
-    return (-1);
-  }
-  else {
-    temp = i2cReadByteData(fd,BATT_PROTECT);
-    i2cWriteByteData(fd,BATT_PROTECT, (temp & NDE )  ); 
-  }
-  return(0);
-
 }

--- a/packages/ceti-tag-data-capture/src/battery.c
+++ b/packages/ceti-tag-data-capture/src/battery.c
@@ -167,24 +167,57 @@ int getBatteryData(double* battery_v1_v, double* battery_v2_v,
 // Charge and Discharge Enabling
 //-----------------------------------------------------------------------------
 int enableCharging() {
-
+  int fd, temp;
+  if((fd=i2cOpen(1,ADDR_BATT_GAUGE,0)) < 0) {
+    CETI_LOG("XXXX Failed to connect to the battery gauge XXXX");
+    return (-1);
+  }
+  else {
+    temp = i2cReadByteData(fd,BATT_PROTECT);
+    i2cWriteByteData(fd,BATT_PROTECT, (temp | CE ) ); //establish undervoltage cutoff
+  }
   return(0);
 }
 
-int disableCharging() {
 
+int disableCharging() {
+  int fd, temp;
+  if((fd=i2cOpen(1,ADDR_BATT_GAUGE,0)) < 0) {
+    CETI_LOG("XXXX Failed to connect to the battery gauge XXXX");
+    return (-1);
+  }
+  else {
+    temp = i2cReadByteData(fd,BATT_PROTECT);
+    i2cWriteByteData(fd,BATT_PROTECT, (temp & NCE)  ); //establish undervoltage cutoff
+  }
   return(0);
 
 }
 
 int enableDischarging() {
-
+  int fd, temp;
+  if((fd=i2cOpen(1,ADDR_BATT_GAUGE,0)) < 0) {
+    CETI_LOG("XXXX Failed to connect to the battery gauge XXXX");
+    return (-1);
+  }
+  else {
+    temp = i2cReadByteData(fd,BATT_PROTECT);
+    i2cWriteByteData(fd,BATT_PROTECT, (temp | DE )  ); //establish undervoltage cutoff
+  }
   return(0);
 
 }
 
 int disableDischarging() {
-
+  int fd, temp;
+  if((fd=i2cOpen(1,ADDR_BATT_GAUGE,0)) < 0) {
+    CETI_LOG("XXXX Failed to connect to the battery gauge XXXX");
+    return (-1);
+  }
+  else {
+    temp = i2cReadByteData(fd,BATT_PROTECT);
+    i2cWriteByteData(fd,BATT_PROTECT, (temp & NDE )  ); //establish undervoltage cutoff
+  }
   return(0);
 
 }

--- a/packages/ceti-tag-data-capture/src/battery.h
+++ b/packages/ceti-tag-data-capture/src/battery.h
@@ -40,11 +40,19 @@
 #define BATT_CTL_VAL 0X8E  //SETS UV CUTOFF TO 2.6V
 #define BATT_OV_VAL 0x5A //SETS OV CUTOFF TO 4.2V
 
+#define MIN_CHARGE_TEMP (10)
+#define MAX_CHARGE_TEMP (40)
+#define MAX_DISCHARGE_TEMP (50)
+
 //-----------------------------------------------------------------------------
 // Methods
 //-----------------------------------------------------------------------------
 int init_battery();
 int getBatteryData(double* battery_v1_v, double* battery_v2_v, double* battery_i_mA);
+int enableCharging();
+int enableDischarging();
+int disableCharging();
+int disableDischarging();
 void* battery_thread(void* paramPtr);
 
 //-----------------------------------------------------------------------------

--- a/packages/ceti-tag-data-capture/src/battery.h
+++ b/packages/ceti-tag-data-capture/src/battery.h
@@ -42,23 +42,21 @@
 
 #define MIN_CHARGE_TEMP (10)
 #define MAX_CHARGE_TEMP (40)
-#define MIN_DISCHARGE_TEMP (5)
+#define MIN_DISCHARGE_TEMP (0)
 #define MAX_DISCHARGE_TEMP (50)
 
 #define DE 0x01    //BIT 0 set  discharge enable
-#define NDE 0xFE   //BIT 0 clear discharge enable
 #define CE 0x02    //BIT 1 set  charge enable
-#define NCE 0xFD   //BIT 1 clear charge enable
 
 //-----------------------------------------------------------------------------
 // Methods
 //-----------------------------------------------------------------------------
 int init_battery();
 int getBatteryData(double* battery_v1_v, double* battery_v2_v, double* battery_i_mA);
-int enableCharging();
-int enableDischarging();
-int disableCharging();
-int disableDischarging();
+int enableCharging(void);
+int enableDischarging(void);
+int disableCharging(void);
+int disableDischarging(void);
 void* battery_thread(void* paramPtr);
 
 //-----------------------------------------------------------------------------

--- a/packages/ceti-tag-data-capture/src/battery.h
+++ b/packages/ceti-tag-data-capture/src/battery.h
@@ -42,7 +42,13 @@
 
 #define MIN_CHARGE_TEMP (10)
 #define MAX_CHARGE_TEMP (40)
+#define MIN_DISCHARGE_TEMP (5)
 #define MAX_DISCHARGE_TEMP (50)
+
+#define DE 0x01    //BIT 0 set  Discharge Enable
+#define NDE 0xF7   //BIT 0 clear
+#define CE 0x02    //BIT 1 set  Charge Enable
+#define NCE 0xFD   //BIT 1 clear  1111 1101
 
 //-----------------------------------------------------------------------------
 // Methods

--- a/packages/ceti-tag-data-capture/src/battery.h
+++ b/packages/ceti-tag-data-capture/src/battery.h
@@ -45,10 +45,10 @@
 #define MIN_DISCHARGE_TEMP (5)
 #define MAX_DISCHARGE_TEMP (50)
 
-#define DE 0x01    //BIT 0 set  Discharge Enable
-#define NDE 0xF7   //BIT 0 clear
-#define CE 0x02    //BIT 1 set  Charge Enable
-#define NCE 0xFD   //BIT 1 clear  1111 1101
+#define DE 0x01    //BIT 0 set  discharge enable
+#define NDE 0xFE   //BIT 0 clear discharge enable
+#define CE 0x02    //BIT 1 set  charge enable
+#define NCE 0xFD   //BIT 1 clear charge enable
 
 //-----------------------------------------------------------------------------
 // Methods

--- a/packages/ceti-tag-data-capture/src/commands.c
+++ b/packages/ceti-tag-data-capture/src/commands.c
@@ -431,6 +431,15 @@ int handle_command(void) {
         return 0;
     }
 
+    if (!strncmp(g_command, "resetBattTemp", 13)) {
+        CETI_LOG("Resetting the Battery Temperature Flags");
+        resetBattTempFlags();
+        g_rsp_pipe = fopen(RSP_PIPE_PATH, "w");
+        fprintf(g_rsp_pipe, "handle_command(): Battery Temperature Flags Reset\n"); // echo it
+        fclose(g_rsp_pipe);
+        return 0;
+    }
+
     if (!strncmp(g_command, "powerdown", 9)) {
         CETI_LOG("Powering down the tag via the FPGA");
         #if ENABLE_FPGA

--- a/packages/ceti-tag-data-capture/src/commands.h
+++ b/packages/ceti-tag-data-capture/src/commands.h
@@ -17,6 +17,7 @@
 #include "utils/logging.h"
 #include "recovery.h"
 #include "battery.h"
+#include "boardTemperature.h"
 #include "burnwire.h"
 #include "sensors/imu.h"
 #include "systemMonitor.h" // for the global CPU assignment variable to update

--- a/packages/ceti-tag-data-capture/src/commands.h
+++ b/packages/ceti-tag-data-capture/src/commands.h
@@ -17,12 +17,12 @@
 #include "utils/logging.h"
 #include "recovery.h"
 #include "battery.h"
-#include "boardTemperature.h"
 #include "burnwire.h"
 #include "sensors/imu.h"
 #include "systemMonitor.h" // for the global CPU assignment variable to update
 
 #include "sensors/audio.h"
+#include "sensors/boardTemperature.h"
 
 #include <signal.h>
 #include <stdio.h>

--- a/packages/ceti-tag-data-capture/src/sensors/boardTemperature.c
+++ b/packages/ceti-tag-data-capture/src/sensors/boardTemperature.c
@@ -78,7 +78,6 @@ void* boardTemperature_thread(void* paramPtr) {
         global_time_us = get_global_time_us();
         rtc_count = getRtcCount();
 
-//        if(getBoardTemperature(&boardTemperature_c) < 0)        
         if(getTemperatures(&boardTemperature_c,&batteryTemperature_c) < 0)
           strcat(boardTemperature_data_file_notes, "ERROR | ");
 
@@ -97,32 +96,14 @@ void* boardTemperature_thread(void* paramPtr) {
             CETI_LOG("Battery charging disabled, outside thermal limits");
           }
         }
-#if 0   
-        else {  //probably want to require operator to reset this condition rather than have it start by itself.
-          if(charging_disabled) {
-            enableCharging();
-            charging_disabled = 0;
-            CETI_LOG("Battery charging re-enabled, back inside thermal limits");
-          }          
-        }
-#endif 
 
-        if( (batteryTemperature_c > MAX_DISCHARGE_TEMP) ||  (batteryTemperature_c < MIN_DISCHARGE_TEMP) ) {
+        if( (batteryTemperature_c > MAX_DISCHARGE_TEMP) ) {
          if (!discharging_disabled){  
             disableDischarging();
             discharging_disabled = 1;
-            CETI_LOG("Battery discharging disabled, outside thermal limits");
+            CETI_LOG("Battery discharging disabled, outside thermal limit");
           }     
         }
-#if 0
-        else {
-          if (discharging_disabled){   // if there is no external supply, this condition will never occur (the device will turn off)
-            enableDischarging();
-            discharging_disabled = 0;
-            CETI_LOG("Battery discharging re-enabled, back inside thermal limits"); 
-          }
-        }
-#endif
       
         // ******************   End Battery Temperature Checks *********************
         
@@ -206,7 +187,7 @@ int getTemperatures(int *pBoardTemp, int *pBattTemp) {
 int resetBattTempFlags() {
     discharging_disabled = 0;
     charging_disabled = 0;
-    enableDischarging();
-    enableCharging();
+    //enableDischarging();
+    //enableCharging();
     return(0);
 }

--- a/packages/ceti-tag-data-capture/src/sensors/boardTemperature.c
+++ b/packages/ceti-tag-data-capture/src/sensors/boardTemperature.c
@@ -88,8 +88,19 @@ void* boardTemperature_thread(void* paramPtr) {
         // Acquire battery temperature and enable/disable charge and discharge
         if(getBatteryTemperature(&batteryTemperature_c) < 0)
           strcat(boardTemperature_data_file_notes, "ERROR | ");
-        if(batteryTemperature_c > MAX_CHARGE_TEMP) 
+        
+        if( (batteryTemperature_c > MAX_CHARGE_TEMP) &&  (batteryTemperature_c < MIN_CHARGE_TEMP) ) {
           disableCharging();
+          CETI_LOG("Battery charging disabled, outside thermal limits");
+        }
+        else enableCharging();
+
+        if( (batteryTemperature_c > MAX_DISCHARGE_TEMP) &&  (batteryTemperature_c < MIN_DISCHARGE_TEMP) ) {
+          disableDischarging();
+          CETI_LOG("Battery discharging disabled, outside thermal limits");        
+        }
+        else enableDischarging();
+
 
         // Write timing information.
         fprintf(boardTemperature_data_file, "%lld", global_time_us);

--- a/packages/ceti-tag-data-capture/src/sensors/boardTemperature.c
+++ b/packages/ceti-tag-data-capture/src/sensors/boardTemperature.c
@@ -88,7 +88,8 @@ void* boardTemperature_thread(void* paramPtr) {
           strcat(boardTemperature_data_file_notes, "INVALID? | ");
         }
         
-        // ******************   Battery Temperature Checks *****************************************************
+        // ******************   Battery Temperature Checks *************************
+
         if( (batteryTemperature_c > MAX_CHARGE_TEMP) ||  (batteryTemperature_c < MIN_CHARGE_TEMP) ) {          
           if (!charging_disabled){  
             disableCharging();
@@ -96,13 +97,15 @@ void* boardTemperature_thread(void* paramPtr) {
             CETI_LOG("Battery charging disabled, outside thermal limits");
           }
         }
+#if 0   
         else {  //probably want to require operator to reset this condition rather than have it start by itself.
           if(charging_disabled) {
             enableCharging();
             charging_disabled = 0;
             CETI_LOG("Battery charging re-enabled, back inside thermal limits");
           }          
-        } 
+        }
+#endif 
 
         if( (batteryTemperature_c > MAX_DISCHARGE_TEMP) ||  (batteryTemperature_c < MIN_DISCHARGE_TEMP) ) {
          if (!discharging_disabled){  
@@ -111,6 +114,7 @@ void* boardTemperature_thread(void* paramPtr) {
             CETI_LOG("Battery discharging disabled, outside thermal limits");
           }     
         }
+#if 0
         else {
           if (discharging_disabled){   // if there is no external supply, this condition will never occur (the device will turn off)
             enableDischarging();
@@ -118,7 +122,9 @@ void* boardTemperature_thread(void* paramPtr) {
             CETI_LOG("Battery discharging re-enabled, back inside thermal limits"); 
           }
         }
-        // ******************   End Battery Temperature Checks *****************************************************
+#endif
+      
+        // ******************   End Battery Temperature Checks *********************
         
         // Write timing information.
         fprintf(boardTemperature_data_file, "%lld", global_time_us);
@@ -194,5 +200,13 @@ int getTemperatures(int *pBoardTemp, int *pBattTemp) {
     usleep(1000*10);  //experimental
     *pBattTemp  = i2cReadByteData(fd,0x01);
     i2cClose(fd);
+    return(0);
+}
+
+int resetBattTempFlags() {
+    discharging_disabled = 0;
+    charging_disabled = 0;
+    enableDischarging();
+    enableCharging();
     return(0);
 }

--- a/packages/ceti-tag-data-capture/src/sensors/boardTemperature.c
+++ b/packages/ceti-tag-data-capture/src/sensors/boardTemperature.c
@@ -187,7 +187,7 @@ int getTemperatures(int *pBoardTemp, int *pBattTemp) {
 int resetBattTempFlags() {
     discharging_disabled = 0;
     charging_disabled = 0;
-    //enableDischarging();
-    //enableCharging();
+    enableDischarging();
+    enableCharging();
     return(0);
 }

--- a/packages/ceti-tag-data-capture/src/sensors/boardTemperature.c
+++ b/packages/ceti-tag-data-capture/src/sensors/boardTemperature.c
@@ -109,6 +109,8 @@ void* boardTemperature_thread(void* paramPtr) {
 
 //-----------------------------------------------------------------------------
 // Board mounted temperature sensor SA56004 Interface
+//  * This device provides two measurement channels, one of which is a remote 
+//    temperature sesnsing diode attached to the battery cells.
 //-----------------------------------------------------------------------------
 
 int getBoardTemperature(int *pBoardTemp) {
@@ -120,6 +122,19 @@ int getBoardTemperature(int *pBoardTemp) {
     }
 
     *pBoardTemp = i2cReadByteData(fd,0x00);
+    i2cClose(fd);
+    return(0);
+}
+
+int getBatteryTemperature(int *pBattTemp) {
+
+    int fd;
+    if((fd=i2cOpen(1,ADDR_BOARDTEMPERATURE,0)) < 0) {
+        CETI_LOG("XXXX Failed to connect to the temperature sensor XXXX");
+        return(-1);
+    }
+
+    *pBattTemp = i2cReadByteData(fd,0x01);
     i2cClose(fd);
     return(0);
 }

--- a/packages/ceti-tag-data-capture/src/sensors/boardTemperature.h
+++ b/packages/ceti-tag-data-capture/src/sensors/boardTemperature.h
@@ -35,6 +35,7 @@ extern int g_boardTemperature_thread_is_running;
 //-----------------------------------------------------------------------------
 int init_boardTemperature();
 int getBoardTemperature(int *pBoardTemp);
+int getBatteryTemperature(int *pBattTemp);
 void* boardTemperature_thread(void* paramPtr);
 
 #endif // BOARDTEMPERATURE_H

--- a/packages/ceti-tag-data-capture/src/sensors/boardTemperature.h
+++ b/packages/ceti-tag-data-capture/src/sensors/boardTemperature.h
@@ -36,6 +36,7 @@ extern int g_boardTemperature_thread_is_running;
 int init_boardTemperature();
 int getBoardTemperature(int *pBoardTemp);
 int getBatteryTemperature(int *pBattTemp);
+int getTemperatures(int *pBoardTemp, int *pBattTemp);
 void* boardTemperature_thread(void* paramPtr);
 
 #endif // BOARDTEMPERATURE_H

--- a/packages/ceti-tag-data-capture/src/sensors/boardTemperature.h
+++ b/packages/ceti-tag-data-capture/src/sensors/boardTemperature.h
@@ -37,6 +37,7 @@ int init_boardTemperature();
 int getBoardTemperature(int *pBoardTemp);
 int getBatteryTemperature(int *pBattTemp);
 int getTemperatures(int *pBoardTemp, int *pBattTemp);
+int resetBattTempFlags();
 void* boardTemperature_thread(void* paramPtr);
 
 #endif // BOARDTEMPERATURE_H


### PR DESCRIPTION
- Battery cell temperature is monitored and logged in the data_boardTemperature.csv file
- If battery cells are outside of thermal limits (defined in battery.h) then charging and/or discharging is disabled
- To re-enable charging/discharging, the application can be restarted or the new ipc command "resetBattTemp" can be used.