### PR TITLE
restart rsyslog.service on tag service start

### DIFF
--- a/packages/ceti-tag-data-capture/debian/ceti-tag-data-capture.service
+++ b/packages/ceti-tag-data-capture/debian/ceti-tag-data-capture.service
@@ -5,6 +5,7 @@ After=network.target local-fs.target getty.target
 [Service]
 Type=simple
 WorkingDirectory=/opt/ceti-tag-data-capture/ipc
+ExecStartPre=/bin/systemctl restart rsyslog # guarentees syslog has valid file/inode for logging
 ExecStart=/opt/ceti-tag-data-capture/ipc/tagMonitor.sh
 Restart=always
 RestartSec=60

--- a/packages/ceti-tag-data-capture/ipc/tagMonitor.sh
+++ b/packages/ceti-tag-data-capture/ipc/tagMonitor.sh
@@ -162,6 +162,9 @@ mount /boot -o remount,ro
 
 ./tagWake.sh
 
+# Touch grass/logs.
+touch /data/{auth,daemon,debug,kern,messages,syslog,user}.log
+
 # Launch the main recording application in the background.
 /opt/ceti-tag-data-capture/bin/cetiTagApp &
 child=$!

--- a/packages/ceti-tag-data-capture/ipc/tagMonitor.sh
+++ b/packages/ceti-tag-data-capture/ipc/tagMonitor.sh
@@ -162,9 +162,6 @@ mount /boot -o remount,ro
 
 ./tagWake.sh
 
-# Touch grass/logs.
-touch /data/{auth,daemon,debug,kern,messages,syslog,user}.log
-
 # Launch the main recording application in the background.
 /opt/ceti-tag-data-capture/bin/cetiTagApp &
 child=$!

--- a/packages/ceti-tag-data-capture/src/cetiTagApp/utils/config.c
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/utils/config.c
@@ -59,8 +59,6 @@ static ConfigError __config_parse_surface_pressure(const char *_String);
 static ConfigError __config_parse_dive_pressure(const char *_String);
 static ConfigError __config_parse_release_voltage(const char *_String);
 static ConfigError __config_parse_critical_voltage(const char *_String);
-static ConfigError __config_parse_cell_release_voltage(const char *_String);
-static ConfigError __config_parse_cell_critical_voltage(const char *_String);
 static ConfigError __config_parse_timeout(const char *_String);
 static ConfigError __config_parse_time_of_day(const char *_String);
 static ConfigError __config_parse_burn_interval_value(const char *_String);


### PR DESCRIPTION
`ceti-tag-data-capture.service` restarts `rsyslog.service` to guarantee log files are created and file inodes used by rsyslog are valid when service starts running. Addresses #92 