### PR TITLE
Removing sleep from the ECG sampling loop.

### DIFF
--- a/packages/ceti-tag-data-capture/src/cetiTagApp/sensors/ecg.c
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/sensors/ecg.c
@@ -267,7 +267,10 @@ void *ecg_thread_getData(void *paramPtr) {
             should_reinitialize = 1;
             CETI_DEBUG("XXX Reading a sample took %ld us", instantaneous_sampling_period_us);
         }
+
+        // Update state.
         first_sample = 0;
+        
         // If the ADC or the GPIO expander had an error,
         //  wait a bit and then try to reconnect to them.
         if (should_reinitialize && !g_stopAcquisition) {
@@ -291,12 +294,17 @@ void *ecg_thread_getData(void *paramPtr) {
             sem_post(sem_ecg_page);
         }
         sem_post(sem_ecg_sample);
-
+        
+        // Note: The below sleep was commented since it seems to be associated with periodically varying
+        //       sampling rates and with artifacts in the ECG spectrogram.  This will be futher investigated,
+        //       but for now it is removed to improve signal integrity.
+        // Note: Sleeping for 75% of the sample interval seems to reduce utilization of this CPU core from 
+        //       approximately 85% to 9%, and seems to reduce overall power consumption by approximately 10%.
         // // sleep duration shortened to 75% of sample interval to ensure ADC config still dictates sampling interval
-        int64_t elapsed_time = (get_global_time_us() - prev_ecg_adc_latest_reading_global_time_us);
-        if ((ECG_SAMPLING_PERIOD_US * 75 / 100 - elapsed_time) > 0) {
-            usleep(ECG_SAMPLING_PERIOD_US * 75 / 100 - elapsed_time);
-        }
+        // int64_t elapsed_time = (get_global_time_us() - prev_ecg_adc_latest_reading_global_time_us);
+        // if ((ECG_SAMPLING_PERIOD_US * 75 / 100 - elapsed_time) > 0) {
+        //     usleep(ECG_SAMPLING_PERIOD_US * 75 / 100 - elapsed_time);
+        // }
     }
     // Print the duration and the sampling rate.
     long long duration_ms = get_global_time_ms() - start_time_ms;


### PR DESCRIPTION
The additional sleep reduces power consumption and CPU usage, but may be associated with ECG signal artifacts.