### PR TITLE
Adding a patch to ignore low voltages within the first 10 seconds of …

### DIFF
--- a/packages/ceti-tag-data-capture/src/cetiTagApp/_versioning.h
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/_versioning.h
@@ -23,7 +23,7 @@
 #ifndef CETI_VERSIONING_H
 #define CETI_VERSIONING_H
 
-#define CETI_VERSION "branch v2_5 New hardware design and ECG not sleepy - V2.5"
+#define CETI_VERSION "branch v2_5 ECG not sleepy | Burnwire patch - V2.5"
 
 #endif // CETI_VERSIONING_H
 

--- a/packages/ceti-tag-data-capture/src/cetiTagApp/state_machine.c
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/state_machine.c
@@ -406,9 +406,11 @@ int updateStateMachine() {
             if (shm_battery->error == WT_OK) {
                 s_bms_error_count = 0;
                 if ((shm_battery->cell_voltage_v[0] < g_config.release_voltage_v) || (shm_battery->cell_voltage_v[1] < g_config.release_voltage_v)) {
-                    CETI_LOG("LOW VOLTAGE!!! Initializing Burn");
-                    stateMachine_set_state(ST_BRN_ON);
-                    break;
+                    if (get_global_time_s() - start_time_s > 10) {
+                        CETI_LOG("LOW VOLTAGE!!! Initializing Burn");
+                        stateMachine_set_state(ST_BRN_ON);
+                        break;
+                    }
                 }
             } else {
                 // report new errors
@@ -471,9 +473,11 @@ int updateStateMachine() {
             if (shm_battery->error == WT_OK) {
                 s_bms_error_count = 0;
                 if ((shm_battery->cell_voltage_v[0] < g_config.release_voltage_v) || (shm_battery->cell_voltage_v[1] < g_config.release_voltage_v)) {
-                    CETI_LOG("LOW VOLTAGE!!! Initializing Burn");
-                    stateMachine_set_state(ST_BRN_ON);
-                    break;
+                    if (get_global_time_s() - start_time_s > 10) {
+                        CETI_LOG("LOW VOLTAGE!!! Initializing Burn");
+                        stateMachine_set_state(ST_BRN_ON);
+                        break;
+                    }
                 }
             } else {
                 // report new errors


### PR DESCRIPTION
…starting the app.

-- During some tests, transient initial power spikes caused a transition to the burnwire state.