### PR TITLE
Update low battery checks (use a counter threshold); update filenames for tag info.

### DIFF
--- a/packages/ceti-tag-data-capture/ipc/tagMonitor.sh
+++ b/packages/ceti-tag-data-capture/ipc/tagMonitor.sh
@@ -169,7 +169,10 @@ child=$!
 
 # Wait for the main loops to start so it is ready to receive commands.
 sleep $STARTUP_TIME
+
+# Initialize some state.
 data_acquisition_running=1
+critical_voltage_shutdown_counter=0
 
 # Periodically monitor the battery, SD storage, and audio overflows.
 while :; do
@@ -195,8 +198,7 @@ while :; do
 		echo "disk space is OK"
 	fi
 
-	#loop timing and initial delay so the user has time to log in before the
-	#script shuts the system down
+	# sleep to set the polling period
 	sleep $SLEEP_TIME
 
 	# check the cell voltages and power off if needed.
@@ -231,7 +233,7 @@ while :; do
 	if [ "$is_discharging" -gt 0 ]; then
 		echo "Batteries are discharging"
 
-		# If either cell is less than 3.10 V:
+		# If either cell is less than 3.10 V for at least 2 samples:
 		#    -signal the FPGA to disable charging and discharging
 		#    -schedule Pi shutdown
 
@@ -239,6 +241,11 @@ while :; do
 		check2=$(echo "$v2 < 3.10" | bc)
 
 		if [ "$check1" -gt 0 ] || [ "$check2" -gt 0 ]; then
+			((critical_voltage_shutdown_counter++))
+		else
+			critical_voltage_shutdown_counter=0
+		fi
+		if (( critical_voltage_shutdown_counter >= 2 )); then
 			echo "low battery cell detected; powering down the Pi now!"
 			echo s >/proc/sysrq-trigger
 
@@ -253,6 +260,8 @@ while :; do
 			echo u >/proc/sysrq-trigger
 			shutdown -P +1
 			break
+		elif (( critical_voltage_shutdown_counter >= 1 )); then
+			echo "low battery cell detected; will wait to confirm with another sample"
 		else
 			echo "battery is OK"
 		fi

--- a/packages/ceti-tag-data-capture/src/cetiTagApp/_versioning.h
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/_versioning.h
@@ -23,7 +23,7 @@
 #ifndef CETI_VERSIONING_H
 #define CETI_VERSIONING_H
 
-#define CETI_VERSION "branch v2_5 ECG not sleepy | Burnwire patch - V2.5"
+#define CETI_VERSION "branch v2_5 Low battery windowing - V2.5"
 
 #endif // CETI_VERSIONING_H
 

--- a/packages/ceti-tag-data-capture/src/cetiTagApp/launcher.c
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/launcher.c
@@ -257,6 +257,7 @@ int main(void) {
 #ifdef DEBUG
     int logcount = 20;
 #endif
+    int meta_files_iteration_countdown = 600;
     while (!g_exit) {
         // Let threads do their work.
         usleep(100000);
@@ -282,6 +283,20 @@ int main(void) {
             usleep(100000);
         }
 #endif
+
+        // Create files with the configuration and other metadata.
+        // Wait a bit after startup, so the system clock can be adjusted.
+        if (meta_files_iteration_countdown > 0) {
+            meta_files_iteration_countdown--;
+            if (meta_files_iteration_countdown == 0) {
+                // Log the configuration used for this deployment.
+                uint64_t start_timestamp = get_global_time_us();
+                // Log tag metadata and runtime configuration.
+                config_log(start_timestamp);
+                meta_log(start_timestamp);
+            }
+        }
+
 #ifdef DEBUG
         if (logcount == 0) {
             int num_threads_running = 0;
@@ -379,13 +394,6 @@ int init_tag() {
     config_read(config_file_path);
     CETI_LOG("Reading current settings from %s", CETI_CONFIG_OVERWRITE_FILE);
     config_read(CETI_CONFIG_OVERWRITE_FILE);
-
-    // Log used config used this deployment
-
-    uint64_t start_timestamp = get_global_time_us();
-    // Log tag metadata and runtime config
-    config_log(start_timestamp);
-    meta_log(start_timestamp);
 
     // Tag-wide initialization.
     if (gpioInitialise() < 0) {

--- a/packages/ceti-tag-data-capture/src/cetiTagApp/state_machine.c
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/state_machine.c
@@ -289,6 +289,8 @@ void stateMachine_resume(void) {
 
 int updateStateMachine() {
     static int s_bms_error_count = 0;
+    static int battery_low_voltage_count = 0;
+    static int battery_critical_voltage_count = 0;
 
     // Deployment sequencer FSM
     switch (presentState) {
@@ -406,11 +408,15 @@ int updateStateMachine() {
             if (shm_battery->error == WT_OK) {
                 s_bms_error_count = 0;
                 if ((shm_battery->cell_voltage_v[0] < g_config.release_voltage_v) || (shm_battery->cell_voltage_v[1] < g_config.release_voltage_v)) {
-                    if (get_global_time_s() - start_time_s > 10) {
-                        CETI_LOG("LOW VOLTAGE!!! Initializing Burn");
-                        stateMachine_set_state(ST_BRN_ON);
-                        break;
-                    }
+                    battery_low_voltage_count++;
+                }
+                else {
+                    battery_low_voltage_count = 0;
+                }
+                if (battery_low_voltage_count >= BATTERY_LOW_VOLTAGE_CONSECUTIVE_THRESHOLD) {
+                    CETI_LOG("LOW VOLTAGE!!! Initializing Burn from Diving");
+                    stateMachine_set_state(ST_BRN_ON);
+                    break;
                 }
             } else {
                 // report new errors
@@ -473,11 +479,15 @@ int updateStateMachine() {
             if (shm_battery->error == WT_OK) {
                 s_bms_error_count = 0;
                 if ((shm_battery->cell_voltage_v[0] < g_config.release_voltage_v) || (shm_battery->cell_voltage_v[1] < g_config.release_voltage_v)) {
-                    if (get_global_time_s() - start_time_s > 10) {
-                        CETI_LOG("LOW VOLTAGE!!! Initializing Burn");
-                        stateMachine_set_state(ST_BRN_ON);
-                        break;
-                    }
+                    battery_low_voltage_count++;
+                }
+                else {
+                    battery_low_voltage_count = 0;
+                }
+                if (battery_low_voltage_count >= BATTERY_LOW_VOLTAGE_CONSECUTIVE_THRESHOLD) {
+                    CETI_LOG("LOW VOLTAGE!!! Initializing Burn from Surface");
+                    stateMachine_set_state(ST_BRN_ON);
+                    break;
                 }
             } else {
                 // report new errors
@@ -518,6 +528,12 @@ int updateStateMachine() {
             if (shm_battery->error == WT_OK) {
                 s_bms_error_count = 0;
                 if ((shm_battery->cell_voltage_v[0] < g_config.critical_voltage_v) || (shm_battery->cell_voltage_v[1] < g_config.critical_voltage_v)) {
+                    battery_critical_voltage_count++
+                }
+                else {
+                    battery_critical_voltage_count = 0;
+                }
+                if (battery_critical_voltage_count >= BATTERY_CRITICAL_VOLTAGE_CONSECUTIVE_THRESHOLD) {
                     CETI_LOG("CRITICAL VOLTAGE!!! Terminating Burn Early");
                     stateMachine_set_state(ST_SHUTDOWN);
                     break;
@@ -550,6 +566,12 @@ int updateStateMachine() {
             if (shm_battery->error == WT_OK) {
                 s_bms_error_count = 0;
                 if ((shm_battery->cell_voltage_v[0] < g_config.critical_voltage_v) || (shm_battery->cell_voltage_v[1] < g_config.critical_voltage_v)) {
+                    battery_critical_voltage_count++
+                }
+                else {
+                    battery_critical_voltage_count = 0;
+                }
+                if (battery_critical_voltage_count >= BATTERY_CRITICAL_VOLTAGE_CONSECUTIVE_THRESHOLD) {
                     CETI_LOG("CRITICAL VOLTAGE!!! Terminating Retreival");
                     stateMachine_set_state(ST_SHUTDOWN);
                     break;

--- a/packages/ceti-tag-data-capture/src/cetiTagApp/state_machine.c
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/state_machine.c
@@ -528,7 +528,7 @@ int updateStateMachine() {
             if (shm_battery->error == WT_OK) {
                 s_bms_error_count = 0;
                 if ((shm_battery->cell_voltage_v[0] < g_config.critical_voltage_v) || (shm_battery->cell_voltage_v[1] < g_config.critical_voltage_v)) {
-                    battery_critical_voltage_count++
+                    battery_critical_voltage_count++;
                 }
                 else {
                     battery_critical_voltage_count = 0;
@@ -566,7 +566,7 @@ int updateStateMachine() {
             if (shm_battery->error == WT_OK) {
                 s_bms_error_count = 0;
                 if ((shm_battery->cell_voltage_v[0] < g_config.critical_voltage_v) || (shm_battery->cell_voltage_v[1] < g_config.critical_voltage_v)) {
-                    battery_critical_voltage_count++
+                    battery_critical_voltage_count++;
                 }
                 else {
                     battery_critical_voltage_count = 0;

--- a/packages/ceti-tag-data-capture/src/cetiTagApp/state_machine.h
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/state_machine.h
@@ -38,6 +38,8 @@ static const char state_str[][MAX_STATE_STRING_LEN] = {
 
 #define WIFI_GRACE_PERIOD_MIN 10
 #define MISSION_BMS_CONSECUTIVE_ERROR_THRESHOLD 5
+#define BATTERY_LOW_VOLTAGE_CONSECUTIVE_THRESHOLD 10
+#define BATTERY_CRITICAL_VOLTAGE_CONSECUTIVE_THRESHOLD 10
 
 //-----------------------------------------------------------------------------
 // Global variables

--- a/packages/ceti-tag-data-capture/src/cetiTagApp/utils/config.c
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/utils/config.c
@@ -501,7 +501,16 @@ void config_log(uint64_t timestamp) {
     // Open file data_config_timestamp.txt
     char config_file_path[256];
 
-    snprintf(config_file_path, 255, "/data/data_config_%lu.txt", timestamp);
+    // Create a name for the info file.
+    // Append a number to the filename base until one is found that doesn't exist yet.
+    int filename_postfix_count = 0;
+    int filename_exists = 0;
+    do {
+        snprintf(config_file_path, 255, "/data/data_config_%lu_%02d.txt", timestamp, filename_postfix_count);
+        filename_exists = (access(config_file_path, F_OK) != -1);
+        filename_postfix_count++;
+    } while (filename_exists);
+
     FILE *fConfig = fopen(config_file_path, "wt");
     if (fConfig == NULL) {
         return;

--- a/packages/ceti-tag-data-capture/src/cetiTagApp/utils/config.c
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/utils/config.c
@@ -506,7 +506,12 @@ void config_log(uint64_t timestamp) {
     int filename_postfix_count = 0;
     int filename_exists = 0;
     do {
-        snprintf(config_file_path, 255, "/data/data_config_%lu_%02d.txt", timestamp, filename_postfix_count);
+        if (filename_postfix_count == 0) {
+            snprintf(config_file_path, 255, "/data/data_config_%lu.txt", timestamp, filename_postfix_count);
+        }
+        else {
+            snprintf(config_file_path, 255, "/data/data_config_%lu_%02d.txt", timestamp, filename_postfix_count);
+        }
         filename_exists = (access(config_file_path, F_OK) != -1);
         filename_postfix_count++;
     } while (filename_exists);

--- a/packages/ceti-tag-data-capture/src/cetiTagApp/utils/meta.c
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/utils/meta.c
@@ -18,7 +18,12 @@ int meta_log(uint64_t timestamp) {
     int filename_postfix_count = 0;
     int filename_exists = 0;
     do {
-        snprintf(meta_file_path, 255, "/data/data_tag_info_%lu_%02d.yaml", timestamp, filename_postfix_count);
+        if (filename_postfix_count == 0) {
+            snprintf(meta_file_path, 255, "/data/data_tag_info_%lu.yaml", timestamp);
+        }
+        else {
+            snprintf(meta_file_path, 255, "/data/data_tag_info_%lu_%02d.yaml", timestamp, filename_postfix_count);
+        }
         filename_exists = (access(meta_file_path, F_OK) != -1);
         filename_postfix_count++;
     } while (filename_exists);

--- a/packages/ceti-tag-data-capture/src/cetiTagApp/utils/meta.c
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/utils/meta.c
@@ -13,7 +13,15 @@ int meta_log(uint64_t timestamp) {
     int nread;
     char meta_file_path[256];
 
-    snprintf(meta_file_path, 255, "/data/data_tag_info_%lu.yaml", timestamp);
+    // Create a name for the info file.
+    // Append a number to the filename base until one is found that doesn't exist yet.
+    int filename_postfix_count = 0;
+    int filename_exists = 0;
+    do {
+        snprintf(meta_file_path, 255, "/data/data_tag_info_%lu_%02d.yaml", timestamp, filename_postfix_count);
+        filename_exists = (access(meta_file_path, F_OK) != -1);
+        filename_postfix_count++;
+    } while (filename_exists);
 
     fd_src = open(META_FILE_PATH, O_RDONLY);
     if (fd_src < 0) {


### PR DESCRIPTION
-- Use a threshold of low/critical battery voltage readings instead of acting on a single sample.
-- Ensure unique filenames for the deployment tag info and config files.