### PR TITLE
Add Depth-Aware Burnwire Control

### DIFF
--- a/packages/ceti-tag-data-capture/src/cetiTagApp/launcher.h
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/launcher.h
@@ -67,6 +67,7 @@
 #define RECOVERY_DATA_FILEPATH "/data/data_gps.csv"
 #define STATEMACHINE_DATA_FILEPATH "/data/data_state.csv"
 #define STATEMACHINE_BURNWIRE_TIMEOUT_START_TIME_FILEPATH "/data/burnwire_timeout_start_time_s.csv"
+#define STATEMACHINE_BURNWIRE_EVENTS_FILEPATH "/data/data_burnwire.csv"
 #define SYSTEMMONITOR_DATA_FILEPATH "/data/data_systemMonitor.csv"
 
 #define CETI_CONFIG_FILE "../config/ceti-config.txt"              // This is non-volatile config file's relative path

--- a/packages/ceti-tag-data-capture/src/cetiTagApp/state_machine.c
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/state_machine.c
@@ -54,6 +54,9 @@ static BurnStartSource burnwire_start_source_s = BSS_NONE;
 static unsigned int burnwire_timeout_start_s = 0;
 static int64_t burnwire_time_of_day_release_s = 0;
 static uint32_t burnwire_started_time_s = 0;
+static uint32_t burnwire_active_time_s = 0;
+static uint32_t burnwire_calendar_start_s = 0;
+static int burnwire_was_underwater = 0;
 static int s_state_machine_paused = 0;
 // Output file
 int g_stateMachine_thread_is_running = 0;
@@ -64,6 +67,32 @@ static const char *stateMachine_data_file_headers[] = {
     "Next State",
 };
 static const int num_stateMachine_data_file_headers = sizeof(stateMachine_data_file_headers) / sizeof(*stateMachine_data_file_headers);
+
+// Helper function to log burnwire events with depth data
+static void log_burnwire_event(const char *event, uint32_t active_time_s, uint32_t calendar_elapsed_s, float pressure_bar, int underwater) {
+    FILE *fp = fopen(STATEMACHINE_BURNWIRE_EVENTS_FILEPATH, "a");
+    if (fp == NULL) {
+        return;
+    }
+
+    // Write header if file is new/empty
+    fseek(fp, 0, SEEK_END);
+    if (ftell(fp) == 0) {
+        fprintf(fp, "SysTime_us,RtcTime_s,Notes,ActiveBurn_s,CalendarElapsed_s,Pressure_bar,Underwater,Event\n");
+    }
+
+    // Follow standard format: sys_time_us, rtc_time_s, notes, then data columns
+    fprintf(fp, "%ld", get_global_time_us());
+    fprintf(fp, ",%d", getRtcCount());
+    fprintf(fp, ",");  // Empty notes column
+    fprintf(fp, ",%u", active_time_s);
+    fprintf(fp, ",%u", calendar_elapsed_s);
+    fprintf(fp, ",%.3f", pressure_bar);
+    fprintf(fp, ",%d", underwater);
+    fprintf(fp, ",%s", event);
+    fprintf(fp, "\n");
+    fclose(fp);
+}
 
 int init_stateMachine() {
     CETI_LOG("Successfully initialized the state machine");
@@ -234,12 +263,23 @@ int stateMachine_set_state(wt_state_t new_state) {
         case ST_BRN_ON:
 // Turn on the burnwire and record the start time.
 #if ENABLE_BURNWIRE
-            burnwireOn();
             burnwire_started_time_s = get_global_time_s();
+            burnwire_active_time_s = 0;
+            burnwire_calendar_start_s = burnwire_started_time_s;
+            burnwire_was_underwater = 0;
+            // Don't turn on burnwire yet - wait until underwater
 #endif // ENABLE_BURNWIRE
 
             // Clear the persistent burnwire timeout start time if one exists.
             remove(STATEMACHINE_BURNWIRE_TIMEOUT_START_TIME_FILEPATH);
+
+#if ENABLE_BURNWIRE && ENABLE_PRESSURETEMPERATURE_SENSOR
+            // Log burn start event
+            if (g_pressure->error == WT_OK) {
+                log_burnwire_event("burn_start", 0, 0, g_pressure->pressure_bar,
+                                   g_pressure->pressure_bar > g_config.burn_depth_threshold_bar);
+            }
+#endif
             break;
 
         case ST_RETRIEVE:
@@ -524,14 +564,73 @@ int updateStateMachine() {
             }
 #endif
 
-// switch state once the burn is complete
+// Depth-aware burnwire control
 #if ENABLE_BURNWIRE
+#if ENABLE_PRESSURETEMPERATURE_SENSOR
+            // Check pressure sensor health
+            if (g_pressure->error == WT_OK) {
+                // Depth-aware burn: only count active time when underwater
+                int is_underwater = (g_pressure->pressure_bar > g_config.burn_depth_threshold_bar);
+
+                // Handle depth state transitions
+                if (is_underwater && !burnwire_was_underwater) {
+                    burnwireOn();
+                    CETI_LOG("Burnwire ON - submerged (%.2f bar)", g_pressure->pressure_bar);
+                    log_burnwire_event("submerged", burnwire_active_time_s,
+                                       get_global_time_s() - burnwire_calendar_start_s,
+                                       g_pressure->pressure_bar, 1);
+                } else if (!is_underwater && burnwire_was_underwater) {
+                    burnwireOff();
+                    CETI_LOG("Burnwire OFF - surfaced (%.2f bar)", g_pressure->pressure_bar);
+                    log_burnwire_event("surfaced", burnwire_active_time_s,
+                                       get_global_time_s() - burnwire_calendar_start_s,
+                                       g_pressure->pressure_bar, 0);
+                }
+
+                // Accumulate active burn time only when underwater
+                if (is_underwater) {
+                    burnwire_active_time_s++;
+                }
+
+                burnwire_was_underwater = is_underwater;
+
+                // Exit when active burn time complete
+                if (burnwire_active_time_s >= g_config.burn_interval_s) {
+                    CETI_LOG("Burn complete - active time: %u s, calendar time: %ld s",
+                             burnwire_active_time_s, get_global_time_s() - burnwire_calendar_start_s);
+                    log_burnwire_event("burn_complete", burnwire_active_time_s,
+                                       get_global_time_s() - burnwire_calendar_start_s,
+                                       g_pressure->pressure_bar, is_underwater);
+                    stateMachine_set_state(ST_RETRIEVE);
+                }
+            } else {
+                // Pressure sensor failed - fallback to calendar time
+                static int sensor_error_logged = 0;
+                if (!sensor_error_logged) {
+                    log_burnwire_event("sensor_error", burnwire_active_time_s,
+                                       get_global_time_s() - burnwire_calendar_start_s,
+                                       0.0, 0);
+                    sensor_error_logged = 1;
+                }
+
+                if (get_global_time_s() - burnwire_started_time_s > g_config.burn_interval_s) {
+                    CETI_LOG("Burn complete (sensor error fallback) - calendar time: %ld s",
+                             get_global_time_s() - burnwire_calendar_start_s);
+                    log_burnwire_event("burn_complete_fallback", 0,
+                                       get_global_time_s() - burnwire_calendar_start_s,
+                                       0.0, 0);
+                    stateMachine_set_state(ST_RETRIEVE);
+                }
+            }
+#else
+            // No pressure sensor - use calendar time
             if (get_global_time_s() - burnwire_started_time_s > g_config.burn_interval_s) {
                 stateMachine_set_state(ST_RETRIEVE);
             }
+#endif // ENABLE_PRESSURETEMPERATURE_SENSOR
 #else
             stateMachine_set_state(ST_RETRIEVE);
-#endif
+#endif // ENABLE_BURNWIRE
 
             break;
 

--- a/packages/ceti-tag-data-capture/src/cetiTagApp/utils/config.c
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/utils/config.c
@@ -28,6 +28,7 @@ TagConfig g_config = {
     },
     .surface_pressure = CONFIG_DEFAULT_SURFACE_PRESSURE_BAR, // depth_m is roughly 10*pressure_bar
     .dive_pressure = CONFIG_DEFAULT_DIVE_PRESSURE_BAR,       // depth_m is roughly 10*pressure_bar
+    .burn_depth_threshold_bar = CONFIG_DEFAULT_BURN_DEPTH_THRESHOLD_BAR, // 1m depth for burnwire
     .release_voltage_v = CONFIG_DEFAULT_RELEASE_VOLTAGE_V,
     .critical_voltage_v = CONFIG_DEFAULT_CRITICAL_VOLTAGE_V,
     .timeout_s = CONFIG_DEFAULT_TIMEOUT_S,
@@ -57,6 +58,7 @@ static ConfigError __config_parse_audio_filter_type(const char *_String);
 static ConfigError __config_parse_audio_sample_rate(const char *_String);
 static ConfigError __config_parse_surface_pressure(const char *_String);
 static ConfigError __config_parse_dive_pressure(const char *_String);
+static ConfigError __config_parse_burn_depth_threshold(const char *_String);
 static ConfigError __config_parse_release_voltage(const char *_String);
 static ConfigError __config_parse_critical_voltage(const char *_String);
 static ConfigError __config_parse_timeout(const char *_String);
@@ -80,6 +82,7 @@ const ConfigList config_keys[] = {
 
     {.key = STR_FROM("surface_pressure"), .parse = __config_parse_surface_pressure},
     {.key = STR_FROM("dive_pressure"), .parse = __config_parse_dive_pressure},
+    {.key = STR_FROM("burn_depth_threshold"), .parse = __config_parse_burn_depth_threshold},
     {.key = STR_FROM("release_voltage"), .parse = __config_parse_release_voltage},
     {.key = STR_FROM("critical_voltage"), .parse = __config_parse_critical_voltage},
 
@@ -210,6 +213,24 @@ static ConfigError __config_parse_surface_pressure(const char *_String) {
 
     // ToDo: Check acceptable range
     g_config.surface_pressure = parsed_value;
+    return CONFIG_OK;
+}
+
+static ConfigError __config_parse_burn_depth_threshold(const char *_String) {
+    char *end_ptr;
+    float parsed_value;
+
+    errno = 0;
+    parsed_value = strtof(_String, &end_ptr);
+    if (parsed_value == 0.0f) {
+        if ((_String == end_ptr) || (errno == ERANGE)) {
+            return CONFIG_ERR_INVALID_VALUE;
+        }
+    }
+
+    // ToDo: Check acceptable range
+    g_config.burn_depth_threshold_bar = parsed_value;
+    CETI_DEBUG("burn depth threshold %.2f bar", parsed_value);
     return CONFIG_OK;
 }
 
@@ -509,6 +530,7 @@ void config_log(uint64_t timestamp) {
     fprintf(fConfig, "# Deployment Timestamp: %lu\n", timestamp);
     fprintf(fConfig, "surface_pressure = %.2f # bar\n", g_config.surface_pressure);
     fprintf(fConfig, "dive_pressure = %.2f # bar\n", g_config.dive_pressure);
+    fprintf(fConfig, "burn_depth_threshold = %.2f # bar\n", g_config.burn_depth_threshold_bar);
     fprintf(fConfig, "release_voltage = %.2f # V per cell\n", g_config.release_voltage_v);
     fprintf(fConfig, "critical_voltage = %.2f # V per cell\n", g_config.critical_voltage_v);
     fprintf(fConfig, "timeout_release = %lu # Seconds\n", g_config.timeout_s);

--- a/packages/ceti-tag-data-capture/src/cetiTagApp/utils/config.h
+++ b/packages/ceti-tag-data-capture/src/cetiTagApp/utils/config.h
@@ -19,6 +19,7 @@
 #define CONFIG_DEFAULT_AUDIO_FILTER_TYPE AUDIO_FILTER_WIDEBAND
 #define CONFIG_DEFAULT_SURFACE_PRESSURE_BAR (0.3) // depth_m is roughly 10*pressure_bar
 #define CONFIG_DEFAULT_DIVE_PRESSURE_BAR (0.5)    // depth_m is roughly 10*pressure_bar
+#define CONFIG_DEFAULT_BURN_DEPTH_THRESHOLD_BAR (0.4) // 4m depth for reliable submersion
 #define CONFIG_DEFAULT_RELEASE_VOLTAGE_V (6.4 / 2.0)
 #define CONFIG_DEFAULT_CRITICAL_VOLTAGE_V (6.2 / 2.0)
 #define CONFIG_DEFAULT_TIMEOUT_S (4 * 24 * 60 * 60)
@@ -41,6 +42,7 @@ typedef struct tag_configuration {
     AudioConfig audio;
     float surface_pressure;
     float dive_pressure;
+    float burn_depth_threshold_bar;
     float release_voltage_v;
     float critical_voltage_v;
     time_t timeout_s;

--- a/packages/ceti-tag-data-capture/tests/src/cetiTagApp/state_machine.test.c
+++ b/packages/ceti-tag-data-capture/tests/src/cetiTagApp/state_machine.test.c
@@ -29,6 +29,7 @@ TagConfig g_config = {
     },
     .surface_pressure = CONFIG_DEFAULT_SURFACE_PRESSURE_BAR, // depth_m is roughly 10*pressure_bar
     .dive_pressure = CONFIG_DEFAULT_DIVE_PRESSURE_BAR,       // depth_m is roughly 10*pressure_bar
+    .burn_depth_threshold_bar = CONFIG_DEFAULT_BURN_DEPTH_THRESHOLD_BAR,
     .release_voltage_v = CONFIG_DEFAULT_RELEASE_VOLTAGE_V,
     .critical_voltage_v = CONFIG_DEFAULT_CRITICAL_VOLTAGE_V,
     .timeout_s = CONFIG_DEFAULT_TIMEOUT_S,
@@ -303,11 +304,18 @@ void test__updateStateMachine_ST_BRN_ON_noTimeup_okBattery(void) {
 
 void test__updateStateMachine_ST_BRN_ON_timeup_okBattery(void) {
     g_config.burn_interval_s = 2;
+    g_config.burn_depth_threshold_bar = 0.4; // 4m depth
     stateMachine_set_state(ST_BRN_ON);
     fake_battery_sample.cell_voltage_v[0] = 4.2;
     fake_battery_sample.cell_voltage_v[1] = 4.2;
-    sleep(g_config.burn_interval_s + 1);
-    updateStateMachine();
+    fake_pressure_sample.error = WT_OK;
+    fake_pressure_sample.pressure_bar = 0.5; // Underwater (5m)
+
+    // Need to accumulate active burn time while underwater
+    for (int i = 0; i < g_config.burn_interval_s + 1; i++) {
+        sleep(1);
+        updateStateMachine();
+    }
     TEST_ASSERT_EQUAL(ST_RETRIEVE, stateMachine_get_state());
 }
 
@@ -362,6 +370,86 @@ void test__updateStateMachine_ST_RETRIEVE_errBattery(void) {
     fake_battery_sample.cell_voltage_v[1] = 3.05;
     updateStateMachine();
 
+    TEST_ASSERT_EQUAL(ST_RETRIEVE, stateMachine_get_state());
+}
+
+// Depth-aware burnwire tests
+void test__updateStateMachine_ST_BRN_ON_depthAware_underwater(void) {
+    g_config.burn_interval_s = 5;
+    g_config.burn_depth_threshold_bar = 0.4; // 4m depth
+    stateMachine_set_state(ST_BRN_ON);
+    fake_battery_sample.cell_voltage_v[0] = 4.2;
+    fake_battery_sample.cell_voltage_v[1] = 4.2;
+    fake_pressure_sample.error = WT_OK;
+    fake_pressure_sample.pressure_bar = 0.5; // Underwater (5m)
+
+    // Should accumulate active burn time when underwater
+    for (int i = 0; i < g_config.burn_interval_s + 1; i++) {
+        sleep(1);
+        updateStateMachine();
+    }
+    TEST_ASSERT_EQUAL(ST_RETRIEVE, stateMachine_get_state());
+}
+
+void test__updateStateMachine_ST_BRN_ON_depthAware_surface(void) {
+    g_config.burn_interval_s = 3;
+    g_config.burn_depth_threshold_bar = 0.4; // 4m depth
+    stateMachine_set_state(ST_BRN_ON);
+    fake_battery_sample.cell_voltage_v[0] = 4.2;
+    fake_battery_sample.cell_voltage_v[1] = 4.2;
+    fake_pressure_sample.error = WT_OK;
+    fake_pressure_sample.pressure_bar = 0.05; // At surface (<4m)
+
+    // Should NOT accumulate active burn time when at surface
+    sleep(g_config.burn_interval_s + 1);
+    updateStateMachine();
+    TEST_ASSERT_EQUAL(ST_BRN_ON, stateMachine_get_state()); // Still burning
+}
+
+void test__updateStateMachine_ST_BRN_ON_depthAware_surfaceAndDive(void) {
+    g_config.burn_interval_s = 10;
+    g_config.burn_depth_threshold_bar = 0.4; // 4m depth
+    stateMachine_set_state(ST_BRN_ON);
+    fake_battery_sample.cell_voltage_v[0] = 4.2;
+    fake_battery_sample.cell_voltage_v[1] = 4.2;
+    fake_pressure_sample.error = WT_OK;
+
+    // Simulate whale breathing pattern: dive, surface, dive
+    // 5 seconds underwater
+    fake_pressure_sample.pressure_bar = 0.5; // Underwater
+    for (int i = 0; i < 5; i++) {
+        sleep(1);
+        updateStateMachine();
+    }
+    TEST_ASSERT_EQUAL(ST_BRN_ON, stateMachine_get_state());
+
+    // 2 seconds at surface (shouldn't count)
+    fake_pressure_sample.pressure_bar = 0.05; // Surface
+    for (int i = 0; i < 2; i++) {
+        sleep(1);
+        updateStateMachine();
+    }
+    TEST_ASSERT_EQUAL(ST_BRN_ON, stateMachine_get_state());
+
+    // 5 more seconds underwater (total 10 active seconds)
+    fake_pressure_sample.pressure_bar = 0.5; // Underwater
+    for (int i = 0; i < 5; i++) {
+        sleep(1);
+        updateStateMachine();
+    }
+    TEST_ASSERT_EQUAL(ST_RETRIEVE, stateMachine_get_state()); // Burn complete
+}
+
+void test__updateStateMachine_ST_BRN_ON_depthAware_sensorError_fallback(void) {
+    g_config.burn_interval_s = 2;
+    stateMachine_set_state(ST_BRN_ON);
+    fake_battery_sample.cell_voltage_v[0] = 4.2;
+    fake_battery_sample.cell_voltage_v[1] = 4.2;
+    fake_pressure_sample.error = WT_RESULT(WT_DEV_PRESSURE, 1); // Generic error
+
+    // Should fallback to calendar time when sensor fails
+    sleep(g_config.burn_interval_s + 1);
+    updateStateMachine();
     TEST_ASSERT_EQUAL(ST_RETRIEVE, stateMachine_get_state());
 }
 


### PR DESCRIPTION
## Add Depth-Aware Burnwire Control

Closes #86

### Summary

Implements depth-aware burnwire activation that only heats the burnwire when the tag is underwater, preventing battery waste and ensures wire degradation works as designed.

### Implementation

**Logic:**
- Monitors pressure sensor each second in `ST_BRN_ON` state
- Activates burnwire when `pressure > burn_depth_threshold` (default 0.4 bar / 4m)
- Accumulates active burn time only while submerged
- Pauses burnwire automatically when tag surfaces
- Transitions to `ST_RETRIEVE` after accumulating configured `burn_interval_s` of underwater time
- Falls back to calendar time if pressure sensor fails

**Configuration:**
- New parameter: `burn_depth_threshold` (default: 0.4 bar)
- Backward compatible - old configs use default value

**Logging:**
- New file `/data/data_burnwire.csv` logs depth transitions, active vs calendar time, and pressure readings

**Testing:**
- 4 new unit tests cover underwater, surface, dive/surface cycles, and sensor failure
- All 27 tests pass
- Full image build successful